### PR TITLE
added missed Register() method calling

### DIFF
--- a/NominationPlugin/ServiceCollectionExtensions.cs
+++ b/NominationPlugin/ServiceCollectionExtensions.cs
@@ -20,6 +20,12 @@ public static class ServiceCollectionExtensions
         foreach (var type in types)
         {
             services.AddSingleton(type);
+
+            var commandHandlerInstance = Activator.CreateInstance(type);
+            if (commandHandlerInstance is ICommandHandler commandHandler)
+            {
+                commandHandler.Register();
+            }
         }
     }
 


### PR DESCRIPTION
… of command handlers when they are added to the service collection. This is achieved by modifying the code to create an instance of each type using `Activator.CreateInstance(type)`. The code then checks if the created instance is of type `ICommandHandler` and if it is, the `Register` method is called on the `commandHandler` instance.

List of Changes:
1. The code has been modified to create an instance of each type using `Activator.CreateInstance(type)`. This allows for dynamic creation of objects at runtime.
2. The code now checks if the created instance is of type `ICommandHandler`. This ensures that only command handlers are registered.
3. If the created instance is of type `ICommandHandler`, the `Register` method is called on the `commandHandler` instance. This allows for the automatic registration of command handlers when they are added to the service collection.

References to the code changes:
- The use of `Activator.CreateInstance(type)` can be found in the updated code.
- The check for `ICommandHandler` type and the call to the `Register` method can also be found in the updated code.