### PR TITLE
Fixed parameterless constructor calling issue

### DIFF
--- a/NominationPlugin/ServiceCollectionExtensions.cs
+++ b/NominationPlugin/ServiceCollectionExtensions.cs
@@ -21,8 +21,7 @@ public static class ServiceCollectionExtensions
         {
             services.AddSingleton(type);
 
-            var commandHandlerInstance = Activator.CreateInstance(type);
-            if (commandHandlerInstance is ICommandHandler commandHandler)
+            if (type is ICommandHandler commandHandler)
             {
                 commandHandler.Register();
             }


### PR DESCRIPTION
The most significant change in the code is the removal of the creation of an instance of each type within the `foreach` loop. Instead of creating an instance, the code now directly checks if the type is an `ICommandHandler`. If it is, the `Register` method is called on it. This modification could potentially enhance performance by avoiding unnecessary object creation.

List of Changes:
1. Removed the creation of an instance of each type within the `foreach` loop. Previously, an instance of each type was created using `Activator.CreateInstance(type)`.
2. The code now directly checks if the type is an `ICommandHandler`. If it is, the `Register` method is called on it. This change could potentially improve performance by avoiding unnecessary object creation.