### PR TITLE
Changed type in DI to `PluginContext`

### DIFF
--- a/NominationPlugin/Handlers/TestCommandHandler.cs
+++ b/NominationPlugin/Handlers/TestCommandHandler.cs
@@ -1,6 +1,7 @@
 ﻿namespace NominationPlugin.Handlers;
 
 using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Core.Plugin;
 using Microsoft.Extensions.Logging;
 
 public class TestCommandHandler : ICommandHandler
@@ -10,10 +11,10 @@ public class TestCommandHandler : ICommandHandler
 
     public TestCommandHandler(
         ILogger<TestCommandHandler> logger,
-        BasePlugin plugin)
+        PluginContext pluginContext)
     {
         _logger = logger;
-        _plugin = plugin;
+        _plugin = (BasePlugin)pluginContext.Plugin;
 
         _logger.LogInformation("Log from ctor");
     }


### PR DESCRIPTION
The most significant changes involve the `TestCommandHandler` class. The constructor now requires an instance of `PluginContext` instead of `BasePlugin`. The `_plugin` field is now assigned by casting the `Plugin` property of the `PluginContext` instance to `BasePlugin`. The previous assignment of the `_plugin` field from the `plugin` parameter has been removed. Additionally, the namespace `CounterStrikeSharp.API.Core.Plugin` has been added to the imports.

List of changes:

1. The namespace `CounterStrikeSharp.API.Core.Plugin` has been added to the imports. This change allows the code to access the classes and methods defined in this namespace without having to use their fully qualified names.

2. The constructor of the `TestCommandHandler` class has been modified. It now takes an instance of `PluginContext` instead of `BasePlugin`. This change reflects a shift in the way the `TestCommandHandler` class interacts with plugins.

3. Inside the constructor of the `TestCommandHandler` class, the `_plugin` field is now assigned by casting the `Plugin` property of the `PluginContext` instance to `BasePlugin`. This change ensures that the `_plugin` field is correctly assigned even though the constructor now takes a `PluginContext` instance.

4. The assignment of the `_plugin` field from the `plugin` parameter in the constructor of the `TestCommandHandler` class has been removed. This change is a direct consequence of the second change, as the `plugin` parameter no longer exists.