### PR TITLE
testing with added IPluginContext dependency

### DIFF
--- a/NominationPlugin/Handlers/TestCommandHandler.cs
+++ b/NominationPlugin/Handlers/TestCommandHandler.cs
@@ -11,7 +11,7 @@ public class TestCommandHandler : ICommandHandler
 
     public TestCommandHandler(
         ILogger<TestCommandHandler> logger,
-        PluginContext pluginContext)
+        IPluginContext pluginContext)
     {
         _logger = logger;
         _plugin = (BasePlugin)pluginContext.Plugin;

--- a/NominationPlugin/ServicesDependencyInjection.cs
+++ b/NominationPlugin/ServicesDependencyInjection.cs
@@ -1,13 +1,14 @@
 ﻿namespace NominationPlugin;
 
 using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Core.Plugin;
 using Microsoft.Extensions.DependencyInjection;
 
 public class ServicesDependencyInjection : IPluginServiceCollection<NominationPlugin>
 {
     public void ConfigureServices(IServiceCollection serviceCollection)
     {
-        serviceCollection.AddSingleton<BasePlugin>();
+        serviceCollection.AddSingleton<IPluginContext>();
         serviceCollection.AddCommandHandlers();
     }
 }


### PR DESCRIPTION
The most significant changes involve modifications to the `TestCommandHandler` class and the `ServicesDependencyInjection.cs` file. In the `TestCommandHandler` class, the constructor's second parameter type has been altered from `PluginContext` to `IPluginContext`. In the `ServicesDependencyInjection.cs` file, the singleton service's type added to the `serviceCollection` has been changed from `BasePlugin` to `IPluginContext`.

Changes:

1. The constructor of the `TestCommandHandler` class in the `TestCommandHandler.cs` file has been modified. The type of the second parameter has been changed from `PluginContext` to `IPluginContext`. This change allows the constructor to accept any object that implements the `IPluginContext` interface, increasing flexibility and promoting loose coupling. (See `TestCommandHandler.cs`)

2. In the `ServicesDependencyInjection.cs` file, the type of the singleton service that is being added to the `serviceCollection` has been changed from `BasePlugin` to `IPluginContext`. This change means that the service collection will now hold an instance of a class that implements the `IPluginContext` interface instead of an instance of the `BasePlugin` class. This change promotes the use of interfaces and enhances the flexibility of the service collection. (See `ServicesDependencyInjection.cs`)